### PR TITLE
Fixed leaking Guzzle exceptions from the HTTP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2025-11-10
+### Fixed
+- Fixed leaking Guzzle exceptions (e.g. `ConnectException`) from the HTTP client. An exception `UnexpectedErrorException` is thrown instead.
+
 ## [1.5.0] - 2024-05-23
 ### Added
 - Added support for content type `noContent`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP client exceptions (e.g., connection errors) leaking to callers. Low-level transport errors are now consistently caught and surfaced as a standardized unexpected-error response, preventing internal implementation details from reaching client code and improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->